### PR TITLE
update script.grab.fanart

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -3,7 +3,7 @@
 	<requires>
 		<import addon="xbmc.gui" version="5.14.0"/>
 		<import addon="resource.uisounds.grid" version="0.0.1"/>
-		<import addon="script.grab.fanart" version="0.14.1"/>
+		<import addon="script.grab.fanart" version="0.15.1"/>
 		<import addon="script.skin.helper.service" version="1.0.11"/>
 		<import addon="script.skinshortcuts" version="1.0.11"/>
 		<import addon="script.watchlist" version="0.0.1"/>


### PR DESCRIPTION
Pretty simple, just updates the script.grab.fanart dependency to use the most current version from the Leia repo. Anyone on Leia will have automatically gotten this update anyway but this just puts the skin in line with the most current version; good for new installs. 

This version of script.grab.fanart is python 2/3 compatible. It will work with future versions of Kodi as it moves to python 3 only addons. I think that happens in the next version if things go as planned. I have had a few reports of issues from a few users that have non-utf-8 encoded information in their Kodi database. I've discussed this with the maintainer of the kodi-six addon and it sounds like when the move to Python 3 happens these errors aren't going to be preventable. You can [read the details here](https://github.com/romanvm/kodi.six/issues/3) if you want. If you want to deny this PR due to that I won't be hurt about it. Sounds like once Python 3 is in full force though people are going to have this problem anyway though, so just kicking the can down the road I think. 